### PR TITLE
User links

### DIFF
--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -14,4 +14,8 @@ class Book < ApplicationRecord
     end
   end
 
+  def highest_review(reviews)
+    reviews.max_by(&:rating)
+  end
+
 end

--- a/app/views/authors/show.html.erb
+++ b/app/views/authors/show.html.erb
@@ -15,8 +15,8 @@
     <h2>Title: <%= review.title %></h2>
     <h2>Description: <%= review.description %></h2>
     <h2>Rating: <%= review.rating %></h2>
-    <h2>User: <%= review.user.name %></h2>
-  <% else %> <h2> Be the first to <a href=<%new_book_review_path(book)%>>review this book!</a></h2>
+    <h2>User: <a href=<%=user_path(review.user)%> ><%= review.user.name %></a></h2>
+  <% else %> <h2> Be the first to <a href=<% new_book_review_path(book) %>>review this book!</a></h2>
   <% end %>
   <p><img src=" <%= book.cover_image %>" alt=" <%= book.title %> image"></p>
   </section>

--- a/app/views/authors/show.html.erb
+++ b/app/views/authors/show.html.erb
@@ -1,17 +1,25 @@
 <h1><%= @author.name %></h1>
 
 <% @author.books.each do |book| %>
+  <section id="book-<%=book.id%>">
   <h2>Title: <%= book.title %> </h2>
   <h2>Length: <%= book.length %> </h2>
   <h2>Year: <%= book.year %> </h2>
-
   <% if book.authors.count > 1 %> <h2>Co-Author(s):
     <% book.authors.each do |book_author| %></h2>
       <h2><%= book_author.name  if @author.name != book_author.name%></h2>
       <% end %>
   <% end %>
-
+  <% if book.reviews.count > 0 %> <h2> Highest Review:
+    <% review = book.highest_review(book.reviews) %></h2>
+    <h2>Title: <%= review.title %></h2>
+    <h2>Description: <%= review.description %></h2>
+    <h2>Rating: <%= review.rating %></h2>
+    <h2>User: <%= review.user.name %></h2>
+  <% else %> <h2> Be the first to <a href=<%new_book_review_path(book)%>>review this book!</a></h2>
+  <% end %>
   <p><img src=" <%= book.cover_image %>" alt=" <%= book.title %> image"></p>
+  </section>
 <% end %>
 
 <%= link_to 'Delete This Author', author_path(@author), method: :delete %>

--- a/app/views/authors/show.html.erb
+++ b/app/views/authors/show.html.erb
@@ -16,7 +16,7 @@
     <h2>Description: <%= review.description %></h2>
     <h2>Rating: <%= review.rating %></h2>
     <h2>User: <a href=<%=user_path(review.user)%> ><%= review.user.name %></a></h2>
-  <% else %> <h2> Be the first to <a href=<% new_book_review_path(book) %>>review this book!</a></h2>
+  <% else %> <h2> Be the first to <%= link_to 'review this book!', new_book_review_path(book) %></h2>
   <% end %>
   <p><img src=" <%= book.cover_image %>" alt=" <%= book.title %> image"></p>
   </section>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -7,10 +7,12 @@
 
 <h1>Reviews</h1>
 <% @book.reviews.each do |review| %>
+<section id="review-<%=review.id%>">
   <h2>Description: <%= review.title %> </h2>
   <h2>Text: <%= review.description %> </h2>
   <h2>Rating: <%= review.rating %> </h2>
-  <h2>User: <%= review.user.name %> </h2>
+  <h2>User: <a href=<%=user_path(review.user)%> ><%= review.user.name %></a></h2>
+</section>
 <% end %>
 
 <%= link_to 'Add a New Review', new_book_review_path(@book) %>

--- a/db/migrate/20190203161119_remove_author_id_from_book.rb
+++ b/db/migrate/20190203161119_remove_author_id_from_book.rb
@@ -1,0 +1,5 @@
+class RemoveAuthorIdFromBook < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :books, :author_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190130230036) do
+ActiveRecord::Schema.define(version: 20190203161119) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,7 +33,6 @@ ActiveRecord::Schema.define(version: 20190130230036) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "cover_image"
-    t.integer "author_id"
   end
 
   create_table "reviews", force: :cascade do |t|

--- a/spec/features/user_sees_an_author_page_spec.rb
+++ b/spec/features/user_sees_an_author_page_spec.rb
@@ -43,14 +43,28 @@ describe 'author show page' do
       expect(page).to have_content( "#{review_1.title}" )
       expect(page).to have_content( "#{review_1.description}" )
       expect(page).to have_content( "Rating: #{review_1.rating}" )
-      expect(page).to have_content( "#{review_1.user}" )
+      expect(page).to have_content( "#{review_1.user.name}" )
     end
 
     within "#book-#{@book_2.id}" do
       expect(page).to have_content( "#{review_4.title}" )
       expect(page).to have_content( "#{review_4.description}" )
       expect(page).to have_content( "Rating: #{review_4.rating}" )
-      expect(page).to have_content( "#{review_4.user}" )
+      expect(page).to have_content( "#{review_4.user.name}" )
+    end
+  end
+
+  context "when there are no user reviews yet" do
+    it "user sees a link to add a review" do
+      visit author_path(@author_1)
+
+      within "#book-#{@book_1.id}" do
+        expect(page).to have_content("review this book!")
+      end
+
+      within "#book-#{@book_2.id}" do
+        expect(page).to have_content("review this book!")
+      end
     end
   end
 

--- a/spec/features/user_sees_an_author_page_spec.rb
+++ b/spec/features/user_sees_an_author_page_spec.rb
@@ -44,6 +44,7 @@ describe 'author show page' do
       expect(page).to have_content( "#{review_1.description}" )
       expect(page).to have_content( "Rating: #{review_1.rating}" )
       expect(page).to have_content( "#{review_1.user.name}" )
+      expect(page).to have_link("April", href: user_path(april))
     end
 
     within "#book-#{@book_2.id}" do
@@ -51,6 +52,7 @@ describe 'author show page' do
       expect(page).to have_content( "#{review_4.description}" )
       expect(page).to have_content( "Rating: #{review_4.rating}" )
       expect(page).to have_content( "#{review_4.user.name}" )
+      expect(page).to have_link("April", href: user_path(april))
     end
   end
 

--- a/spec/features/user_sees_an_author_page_spec.rb
+++ b/spec/features/user_sees_an_author_page_spec.rb
@@ -1,38 +1,57 @@
 require "rails_helper"
 
-describe 'author_show_page' do
-  it "user_can_see_author_books_data" do
-    author_1 = Author.create(name: "Jon Doe")
-    author_2 = Author.create(name: "Jane Doe")
-    book_1 = Book.create(title: "Book 1 Title", length: 111, year: 1111, authors: [author_1], cover_image: "https://images-na.ssl-images-amazon.com/images/I/51jNORv6nQL._SX340_BO1,204,203,200_.jpg")
-    book_2 = Book.create(title: "Book 2 Title", length: 222, year: 2222, authors: [author_1, author_2], cover_image: "http://bookriotcom.c.presscdn.com/wp-content/uploads/2014/08/HP_hc_new_2-e1407533769415.jpeg")
-
-    visit "/authors/#{author_1.id}"
-
-    # save_and_open_page
-    # require 'pry'; binding.pry
-    expect(page).to have_content("#{author_1.name}")
-    expect(page).to have_content("Title: #{book_1.title}")
-    expect(page).to have_content("Length: #{book_1.length}")
-    expect(page).to have_content("Year: #{book_1.year}")
-    expect(page).to have_xpath("//img[contains(@src,'#{File.basename(book_1.cover_image)}')]")
-
-    expect(page).to have_content("Title: #{book_2.title}")
-    expect(page).to have_content("Length: #{book_2.length}")
-    expect(page).to have_content("Year: #{book_2.year}")
-    expect(page).to have_content("Co-Author(s):\n#{author_2.name}")
-    expect(page).to have_xpath("//img[contains(@src,'#{File.basename(book_2.cover_image)}')]")
+describe 'author show page' do
+  before :each do
+    @author_1 = Author.create(name: "Jon Doe")
+    @author_2 = Author.create(name: "Jane Doe")
+    @book_1 = Book.create(title: "Book 1 Title", length: 111, year: 1111, authors: [@author_1], cover_image: "https://images-na.ssl-images-amazon.com/images/I/51jNORv6nQL._SX340_BO1,204,203,200_.jpg")
+    @book_2 = Book.create(title: "Book 2 Title", length: 222, year: 2222, authors: [@author_1, @author_2], cover_image: "http://bookriotcom.c.presscdn.com/wp-content/uploads/2014/08/HP_hc_new_2-e1407533769415.jpeg")
   end
 
-  it "user_doesn't_see_authors_name_under_coauthored_books" do
-    author_1 = Author.create(name: "Jon Doe")
-    author_2 = Author.create(name: "Jane Doe")
-    book_2 = Book.create(title: "Book 2 Title", length: 222, year: 2222, authors: [author_1, author_2], cover_image: "http://bookriotcom.c.presscdn.com/wp-content/uploads/2014/08/HP_hc_new_2-e1407533769415.jpeg")
-    book_1 = Book.create(title: "Book 1 Title", length: 111, year: 1111, authors: [author_1], cover_image: "https://images-na.ssl-images-amazon.com/images/I/51jNORv6nQL._SX340_BO1,204,203,200_.jpg")
+  it "user can see author books data" do
+    visit "/authors/#{@author_1.id}"
 
+    expect(page).to have_content("#{@author_1.name}")
+    expect(page).to have_content("Title: #{@book_1.title}")
+    expect(page).to have_content("Length: #{@book_1.length}")
+    expect(page).to have_content("Year: #{@book_1.year}")
+    expect(page).to have_xpath("//img[contains(@src,'#{File.basename(@book_1.cover_image)}')]")
 
-    visit "/authors/#{author_1.id}"
-
-    expect(page).to have_content("#{author_1.name}", maximum: 1)
+    expect(page).to have_content("Title: #{@book_2.title}")
+    expect(page).to have_content("Length: #{@book_2.length}")
+    expect(page).to have_content("Year: #{@book_2.year}")
+    expect(page).to have_content("Co-Author(s):\n#{@author_2.name}")
+    expect(page).to have_xpath("//img[contains(@src,'#{File.basename(@book_2.cover_image)}')]")
   end
+
+  it "user doesn't see author's name under coauthored books" do
+    visit "/authors/#{@author_1.id}"
+
+    expect(page).to have_content("#{@author_1.name}", maximum: 1)
+  end
+
+  it "user sees top review for each book" do
+    april = User.create(name: "April")
+    review_1 = @book_1.reviews.create(title: "Good book", description: "Liked it", rating: 4, user: april)
+    review_2 = @book_1.reviews.create(title: "Fine book", description: "Liked it enough", rating: 3, user: april)
+    review_3 = @book_2.reviews.create(title: "Boring book", description: "Didn't like it", rating: 2, user: april)
+    review_4 = @book_2.reviews.create(title: "Great book", description: "It was wonderful!", rating: 5, user: april)
+
+    visit author_path(@author_1)
+
+    within "#book-#{@book_1.id}" do
+      expect(page).to have_content( "#{review_1.title}" )
+      expect(page).to have_content( "#{review_1.description}" )
+      expect(page).to have_content( "Rating: #{review_1.rating}" )
+      expect(page).to have_content( "#{review_1.user}" )
+    end
+
+    within "#book-#{@book_2.id}" do
+      expect(page).to have_content( "#{review_4.title}" )
+      expect(page).to have_content( "#{review_4.description}" )
+      expect(page).to have_content( "Rating: #{review_4.rating}" )
+      expect(page).to have_content( "#{review_4.user}" )
+    end
+  end
+
 end

--- a/spec/features/user_sees_an_author_page_spec.rb
+++ b/spec/features/user_sees_an_author_page_spec.rb
@@ -62,10 +62,12 @@ describe 'author show page' do
 
       within "#book-#{@book_1.id}" do
         expect(page).to have_content("review this book!")
+        expect(page).to have_link("review this book!", href: new_book_review_path(@book_1))
       end
 
       within "#book-#{@book_2.id}" do
         expect(page).to have_content("review this book!")
+        expect(page).to have_link("review this book!", href: new_book_review_path(@book_2))
       end
     end
   end

--- a/spec/features/user_sees_book_show_page_spec.rb
+++ b/spec/features/user_sees_book_show_page_spec.rb
@@ -9,8 +9,6 @@ describe 'book_show_page' do
 
     visit book_path(book_1)
 
-    # save_and_open_page
-    # require 'pry'; binding.pry
     expect(page).to have_content( "#{book_1.title}" )
     expect(page).to have_content("Length: #{book_1.length}")
     expect(page).to have_content("Year: #{book_1.year}")
@@ -33,15 +31,20 @@ describe 'book_show_page' do
 
     visit book_path(book_1)
 
-    expect(page).to have_content( "Review 1" )
-    expect(page).to have_content( "I liked this book" )
-    expect(page).to have_content( "April" )
-    expect(page).to have_content( 5 )
-
-    expect(page).to have_content( "Review 2" )
-    expect(page).to have_content( "I didn't like this book" )
-    expect(page).to have_content( "Rene" )
-    expect(page).to have_content( 1 )
+    within "#review-#{review_1.id}" do
+      expect(page).to have_content( "Review 1" )
+      expect(page).to have_content( "I liked this book" )
+      expect(page).to have_content( "April" )
+      expect(page).to have_link("April", href: user_path(april))
+      expect(page).to have_content( 5 )
+    end
+    within "#review-#{review_2.id}" do
+      expect(page).to have_content( "Review 2" )
+      expect(page).to have_content( "I didn't like this book" )
+      expect(page).to have_content( "Rene" )
+      expect(page).to have_link("Rene", href: user_path(rene))
+      expect(page).to have_content( 1 )
+    end
   end
 
 

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Book, type: :model do
   end
 
   describe 'intance methods' do
-    context "deleting a book" do
+    context "in order to delete a book" do
       it "should delete the book's reviews" do
         author_1 = Author.create(name: "Jon Doe")
         author_2 = Author.create(name: "Jane Doe")
@@ -33,6 +33,18 @@ RSpec.describe Book, type: :model do
         expect(book_1.reviews.count).to eq(0)
         expect(Review.count).to eq(1)
       end
+    end
+
+    it "should find the highest review for a book" do
+      author_1 = Author.create(name: "Jon Doe")
+      book_1 = Book.create(title: "Book 1 Title", length: 111, year: 1111, authors: [author_1], cover_image: "https://images-na.ssl-images-amazon.com/images/I/51jNORv6nQL._SX340_BO1,204,203,200_.jpg")
+      april = User.create(name: "April")
+      review_1 = book_1.reviews.create(title: "Good book", description: "Liked it", rating: 4, user: april)
+      review_2 = book_1.reviews.create(title: "Fine book", description: "Liked it enough", rating: 3, user: april)
+      review_3 = book_1.reviews.create(title: "Boring book", description: "Didn't like it", rating: 2, user: april)
+      review_4 = book_1.reviews.create(title: "Great book", description: "It was wonderful!", rating: 5, user: april)
+
+      expect(book_1.highest_review(book_1.reviews)).to eq(review_4)
     end
   end
 end


### PR DESCRIPTION
@renecasco this PR turns all the User names into links to their show pages. It also fixes a problem with the link to add a new review, and it adds the migration to remove the unnecessary author_id column from the Books table.